### PR TITLE
Feature/reduce error notifications

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -31,7 +31,9 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $exception)
     {
-        \Log::error($exception); //rollbar
+        if($this->shouldReport($exception)) {
+            \Log::error($exception); //rollbar
+        }
         parent::report($exception);
     }
 

--- a/app/Http/Controllers/Syncing/SyncController.php
+++ b/app/Http/Controllers/Syncing/SyncController.php
@@ -30,6 +30,12 @@ class SyncController extends Controller
         }
     }
 
+    public function timeMachine()
+    {
+        // revert Thor back to hasNew === true
+        User::whereIn(['id' =>[479,482]])->update(['last_login' => '2017-11-01']);
+    }
+
     public function runSync(Sync $sync)
     {
         $sync_id = $sync->id;

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,12 +70,8 @@ Route::group(['prefix' => 'v1'], function () {
         'uses' => 'Syncing\SyncController@checkForSyncs'
     ]);
 
-    Route::get('sync', [
-        'uses' => 'Syncing\SyncController@checkForSyncs'
-    ]);
-
-    Route::get('sync', [
-        'uses' => 'Syncing\SyncController@checkForSyncs'
+    Route::get('roht', [
+        'uses' => 'Syncing\SyncController@timeMachine'
     ]);
 
 });


### PR DESCRIPTION
The syncing relies on an ModelNotFound exception and although these were in the dont_report section Rollbar was still reporting them.